### PR TITLE
Ballot prep fixes

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,58 +1,67 @@
 == Suppressed Messages ==
 
-# Each pattern below is preceded by a single "# " line that the IG Publisher uses verbatim as the editor's comment shown against the message in qa.html. The publisher keeps only the last comment line before a pattern, so each justification is deliberately written as one long line rather than wrapped.
+# 01. Each pattern below is preceded by a single "# " line that the IG Publisher uses verbatim as the editor's comment shown against the message in qa.html. The publisher keeps only the last comment line before a pattern, so each justification is deliberately written as one long line rather than wrapped.
 
-# ViewDefinition is defined as an additional resource, so the publisher validates SearchParameter.base against the core Version Independent Resource Types (All) value set, which cannot contain a type that is not in the core specification. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 02. ViewDefinition is defined as an additional resource, so the publisher validates SearchParameter.base against the core Version Independent Resource Types (All) value set, which cannot contain a type that is not in the core specification. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %was not found in the value set 'Version Independent Resource Types (All)'%
 %The System URI could not be determined for the code 'ViewDefinition'%
 
-# The publisher requires every instance of an additional resource to carry a resourceDefinition property naming the versioned canonical of its definition. Adding it would put FHIR tooling metadata into the published ViewDefinition examples and pin the IG version in each of them, so the examples are left as authored; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 03. The publisher requires every instance of an additional resource to carry a resourceDefinition property naming the versioned canonical of its definition. Adding it would put FHIR tooling metadata into the published ViewDefinition examples and pin the IG version in each of them, so the examples are left as authored; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %so must have a resourceDefinition of%
 
-# ViewDefinition is an additional resource rather than a core FHIR type, so the publisher rejects its use as a StructureDefinition type. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 04. ViewDefinition is an additional resource rather than a core FHIR type, so the publisher rejects its use as a StructureDefinition type. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %is not legal because it is not defined in the FHIR specification%
 
-# ViewDefinition is a canonical resource, but the publisher does not recognise additional resources as canonical when checking Library.relatedArtifact.resource targetProfiles. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 05. ViewDefinition is a canonical resource, but the publisher does not recognize additional resources as canonical when checking Library.relatedArtifact.resource targetProfiles. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %which is not a Canonical Resource (which is required because the Library.relatedArtifact.resource element has the type canonical)%
 
-# ViewDefinition derives from MetadataResource, so the inherited cnl-1 invariant carries MetadataResource as its source and the publisher reports a mismatch against the deriving profile. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 06. ViewDefinition derives from MetadataResource, so the inherited cnl-1 invariant carries MetadataResource as its source and the publisher reports a mismatch against the deriving profile. Inherent to the additional-resource design; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %The invariant cnl-1 defined in the differential must have no source%
+ED_INVARIANT_DIFF_NO_SOURCE
 
-# These are valid ViewDefinition FHIRPath expressions that the publisher's generic FHIRPath evaluator cannot resolve: %rowIndex is a ViewDefinition constant, and linkId, answer and code are evaluated inside a forEach scope that the evaluator does not apply. See https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
+# 07. These are valid ViewDefinition FHIRPath expressions that the publisher's generic FHIRPath evaluator cannot resolve: %rowIndex is a ViewDefinition constant, and linkId, answer and code are evaluated inside a forEach scope that the evaluator does not apply. See https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Validation.20errors.20for.20additional.20resources/with/615144653.
 %Error evaluating FHIRPath expression: Invalid FHIRPath Constant %rowIndex%
 %Error evaluating FHIRPath expression: The name 'answer' is not valid%
 %Error evaluating FHIRPath expression: The name 'linkId' is not valid%
 %Error evaluating FHIRPath expression: The name 'code' is not valid%
 
-# This IG targets FHIR 6.0.0-ballot3, but no R6 build of hl7.fhir.uv.extensions, hl7.terminology or hl7.fhir.uv.tools has been released; the registry serves only R5-based versions, so the publisher auto-selects the .r5 variants. Nothing in this repository can resolve the mismatch; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/R6.20IGs.20depending.20on.20R5-only.20packages/with/615144821.
+# 08. This IG targets FHIR 6.0.0-ballot3, but no R6 build of hl7.fhir.uv.extensions, hl7.terminology or hl7.fhir.uv.tools has been released; the registry serves only R5-based versions, so the publisher auto-selects the .r5 variants. Nothing in this repository can resolve the mismatch; see https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/R6.20IGs.20depending.20on.20R5-only.20packages/with/615144821.
 This IG is version%
 This IG is for FHIR version%
 IG_DEPENDENCY_VERSION_ERROR
 IG_DEPENDENCY_VERSION_WARNING
 
-# The jurisdiction value set is deprecated in the core specification and this message originates there; the jurisdiction values are inherited from the HL7 universal realm conventions and cannot be changed in this IG.
+# 09. The jurisdiction value set is deprecated in the core specification and this message originates there; the jurisdiction values are inherited from the HL7 universal realm conventions and cannot be changed in this IG.
 %Reference to deprecated ValueSet http://hl7.org/fhir/ValueSet/jurisdiction%
 
-# These code systems are defined in this IG rather than in THO. A TSMG exemption will be sought at a later time.
+# 10. These code systems are defined in this IG rather than in THO. A TSMG exemption will be sought in the future (first publication).
 %will need to move to THO later during the process%
 
-# eld-31 is a best-practice recommendation that additional bindings carry a key. Seven of these are on inherited language elements whose additional binding is defined by the core specification without one; the other four are on the content.contentType binding this IG defines on SQLQuery and SQLView, where a key cannot be supplied because binding.additional.key exists in R6 but not in R5, and the publisher processes these Library profiles through the R5 element model and strips it.
+# 11. eld-31 is a best-practice recommendation that additional bindings carry a key. Seven of these are on inherited language elements whose additional binding is defined by the core specification without one; the other four are on the content.contentType binding this IG defines on SQLQuery and SQLView, where a key cannot be supplied because binding.additional.key exists in R6 but not in R5, and the publisher processes these Library profiles through the R5 element model and strips it.
 %Constraint failed: eld-31%
 
-# eld-33 is a best-practice recommendation that flags any binding on an element with more than one bindable type. The bindings on ViewDefinition.versionAlgorithm[x] and the sql-text choice elements are inherited from the R5 base resources and are deliberate.
+# 12. eld-33 is a best-practice recommendation that flags any binding on an element with more than one bindable type. The bindings on ViewDefinition.versionAlgorithm[x] and the sql-text choice elements are inherited from the R5 base resources and are deliberate.
 %Constraint failed: eld-33%
 
-# The core mimetypes value set is unbounded and cannot be expanded by any terminology server. The required binding is intentional and is supplemented by an extensible additional binding to the SQL content type codes.
+# 13. The core mimetypes value set is unbounded and cannot be expanded by any terminology server. The required binding is intentional and is supplemented by an extensible additional binding to the SQL content type codes.
 %Binding http://hl7.org/fhir/ValueSet/mimetypes%
 
-# The recursive ViewDefinition.select contentReference produces multiple anchors with the same name in the generated narrative, so the auto-generated hyperlink matches more than one target. This is a rendering artefact of the logical model.
+# 14. The recursive ViewDefinition.select contentReference produces multiple anchors with the same name in the generated narrative, so the auto-generated hyperlink matches more than one target. This is a rendering artefact of the logical model.
 %Hyperlink '#ViewDefinition.select' at 'div/table/tr/td/a' for 'select' resolves to multiple targets%
 
-# These template-provided HTML fragments (IP statements, dependency table, globals table) are generated by the template but are not referenced by any page in this IG's layout.
+# 15. These template-provided HTML fragments (IP statements, dependency table, globals table) are generated by the template but are not referenced by any page in this IG's layout.
 %is not included anywhere in the produced implementation guide%
 
-# The operation definitions are active, usable definitions; the draft maturity expressed by standards-status = draft is the IG's overall pre-ballot maturity, not a statement that the operations themselves are drafts. The publisher flags the active/draft pairing as inconsistent, but the two axes describe different things here.
-%The resource status 'active' and the standards status 'draft' are not consistent%
+# 16. The CodeSystem fhirpath-types was incorrectly tagged as experimental: https://jira.hl7.org/browse/FHIR-58168
+%Reference to experimental CodeSystem http://hl7.org/fhir/CodeSystem/fhirpath-types|6.0.0-ballot3
+MSG_EXPERIMENTAL
 
-# The IG maturity (FMM) has not been assigned ahead of the first ballot. An explicit FMM extension will be added when the maturity level is agreed.
-%should state their maturity explicitly using the extension%
+# 17. FHIR R6 Additional Resource mechanisms are still WIP
+UNABLE_TO_INFER_CODESYSTEM
+Terminology_TX_NoValid_16
+%The value provided ('ViewDefinition') was not found in the value set 'Version Independent Resource Types (All)' (http://hl7.org/fhir/ValueSet/version-independent-all-resource-types|6.0.0-ballot3), and a code is required from this value set  (error message = The System URI could not be determined for the code 'ViewDefinition' in the ValueSet 'http://hl7.org/fhir/ValueSet/version-independent-all-resource-types|6.0.0-ballot3'; The provided code '#ViewDefinition' was not found in the value set 'http://hl7.org/fhir/ValueSet/version-independent-all-resource-types|6.0.0-ballot3')
+%The System URI could not be determined for the code 'ViewDefinition' in the ValueSet 'http://hl7.org/fhir/ValueSet/version-independent-all-resource-types|6.0.0-ballot3'
+
+# 18. This is a combinations of bugs - Resource definitions must be namespaced in hl7.org/fhir, and publisher is not processing the JSON version of the example additional resource correctly.
+VALIDATION_ADDITIONAL_RESOURCE_NO_WRONG
+% ViewDefinition: The value for resourceDefinition of 'http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot' does not match the required value of 'http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ShareableViewDefinition|3.0.0-ballot'. In addition, this is not an additional resource, and shouldn't have a resourceDefinition at all

--- a/input/pagecontent/OperationDefinition-SQLExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLExport-notes.md
@@ -16,7 +16,7 @@ This operation follows the [FHIR Asynchronous Interaction Request Pattern](https
 6. Client fetches the result URL; a successful export returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …), and a failed export returns the error status code with an `OperationOutcome`
 7. Client downloads the exported files from the `output.location` URLs in the manifest
 
-The result resource for this operation is the manifest `Parameters` resource described under [Output Parameters](#output-parameters). Clients MUST treat the status and result URLs as opaque values.
+The result resource for this operation is the manifest `Parameters` resource described under [Output Parameters](#output-parameters). <span class="fhir-conformance" id="exp-29">Clients SHALL treat the status and result URLs as opaque values.</span>
 
 ##### Async Flow Diagram
 
@@ -442,7 +442,7 @@ either resolves it.
 }
 ```
 
-Clients MUST download all parts to obtain the complete dataset.
+<span class="fhir-conformance" id="exp-30">Clients SHALL download all parts to obtain the complete dataset.</span>
 
 #### Error Handling
 
@@ -657,8 +657,8 @@ Content-Type: application/fhir+json
    - `Location` header with the absolute result URL
    - An empty body
    - The status endpoint reflects polling machinery only; it never communicates
-     the job's outcome. Clients MUST treat the status and result URLs as opaque
-     values.
+     the job's outcome. <span class="fhir-conformance" id="exp-31">Clients SHALL treat the status and
+     result URLs as opaque values.</span>
 5. **Result Retrieval**: Client fetches the result URL with `GET`:
    - **Success**: `200 OK` with the manifest `Parameters` resource in the body
      containing `status` = `completed`, the export metadata, and one `output`
@@ -679,7 +679,7 @@ Content-Type: application/fhir+json
    export completion:</span>
    - <span class="fhir-conformance" id="exp-25">Servers SHOULD support multiple retrievals of the result</span>
    - <span class="fhir-conformance" id="exp-26">Servers MAY include an `Expires` header to indicate when the URLs expire</span>
-   - Clients SHOULD retrieve results promptly but can retry within the validity window
+   - <span class="fhir-conformance" id="exp-32">Clients SHOULD retrieve results promptly but can retry within the validity window</span>
 8. **Access Control**:
    <span class="fhir-conformance" id="exp-27">Servers SHALL protect status, result, and download URLs with appropriate access controls:</span>
    - <span class="fhir-conformance" id="exp-28">Same authorisation context as the original request (servers SHOULD limit

--- a/input/pagecontent/OperationDefinition-SQLRun-intro.md
+++ b/input/pagecontent/OperationDefinition-SQLRun-intro.md
@@ -33,7 +33,8 @@ and so require `POST`.
 4. Evaluate the view, or execute the SQL
 5. Return results in the requested format (a raw stream for flat formats, a `Parameters` resource for `_format=fhir`)
 
-Implementations MUST ensure parameter values are safely bound to queries and not
-subject to SQL injection. Use parameterized queries or equivalent safe binding
-mechanisms where available. Simple string interpolation MUST NOT be used to
-implement parameter binding.
+<span class="fhir-conformance" id="run-intro-1">Implementations SHALL ensure parameter values are
+safely bound to queries and not subject to SQL injection.</span> Use parameterized
+queries or equivalent safe binding mechanisms where available.
+<span class="fhir-conformance" id="run-intro-2">Simple string interpolation SHALL NOT be used to
+implement parameter binding.</span>

--- a/input/pagecontent/OperationDefinition-SQLRun-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLRun-notes.md
@@ -788,8 +788,8 @@ When a subject returns zero rows, the response is a Parameters resource with no
 
 #### SQL to FHIR type mapping
 
-When `_format=fhir`, each result column SHALL be encoded using a FHIR `value[x]`
-type. The following table defines the mapping from
+<span class="fhir-conformance" id="run-10">When `_format=fhir`, each result column SHALL be
+encoded using a FHIR `value[x]` type.</span> The following table defines the mapping from
 [ISO/IEC 9075](https://www.iso.org/standard/76583.html) SQL types to FHIR
 parameter value types.
 
@@ -828,8 +828,9 @@ the absence of timezone information is preserved rather than trying to infer a
 time zone.
 
 ISO/IEC 9075 types not listed in this table (such as INTERVAL, ARRAY, XML, ROW,
-and MULTISET) are not supported. If a query produces a result column with an
-unsupported type, the server MUST return a `422 Unprocessable Entity` error.
+and MULTISET) are not supported. <span class="fhir-conformance" id="run-11">If a query produces a result
+column with an unsupported type, the server SHALL return a
+`422 Unprocessable Entity` error.</span>
 Query authors can work around this by casting unsupported types to a supported
 type within the SQL query.
 

--- a/input/pagecontent/StructureDefinition-SQLQuery-intro.md
+++ b/input/pagecontent/StructureDefinition-SQLQuery-intro.md
@@ -35,9 +35,9 @@ a `targetProfile` on `relatedArtifact.resource`.
 #### Table Aliases
 
 Each dependency requires a `label` that defines the table name used in SQL.
-Labels SHALL be unique within the Library and valid SQL identifiers (start with
-letter or underscore, contain only letters/digits/underscores, avoid reserved
-words).
+<span class="fhir-conformance" id="sqlquery-14">Labels SHALL be unique within the Library and
+valid SQL identifiers (start with letter or underscore, contain only
+letters/digits/underscores, avoid reserved words).</span>
 
 #### Parameters
 
@@ -56,10 +56,11 @@ Reference parameters in SQL with colon-prefix placeholders (`:name`):
 WHERE patient.id = :patient_id AND bp.effective_date >= :from_date
 ```
 
-Implementations MUST ensure parameter values are safely bound to queries and not
-subject to SQL injection. Use parameterized queries or equivalent safe binding
-mechanisms where available. Simple string interpolation MUST NOT be used to
-implement parameter binding.
+<span class="fhir-conformance" id="sqlquery-15">Implementations SHALL ensure parameter values are
+safely bound to queries and not subject to SQL injection.</span> Use parameterized
+queries or equivalent safe binding mechanisms where available.
+<span class="fhir-conformance" id="sqlquery-16">Simple string interpolation SHALL NOT be used to
+implement parameter binding.</span>
 
 #### SQL Attachments
 

--- a/input/pagecontent/StructureDefinition-SQLQuery-notes.md
+++ b/input/pagecontent/StructureDefinition-SQLQuery-notes.md
@@ -89,12 +89,13 @@ in
 
 ### Parameter Types
 
-Each `Library.parameter` declares a `type` that callers SHALL honour when
-supplying values. When parameters are passed at invocation time via a
-`Parameters` resource (for example to [`$sql-run`](OperationDefinition-SQLRun.html)
+<span class="fhir-conformance" id="sqlquery-notes-5">Each `Library.parameter` declares a `type` that
+callers SHALL honour when supplying values.</span>
+<span class="fhir-conformance" id="sqlquery-notes-6">When parameters are passed at invocation time
+via a `Parameters` resource (for example to [`$sql-run`](OperationDefinition-SQLRun.html)
 or [`$sql-export`](OperationDefinition-SQLExport.html)), each entry
 is bound by name to the matching `Library.parameter`, and the appropriate
-`value[x]` element SHALL be used for the declared type:
+`value[x]` element SHALL be used for the declared type:</span>
 
 | Library.parameter.type | Parameters.parameter value |
 | ---------------------- | -------------------------- |

--- a/input/pagecontent/StructureDefinition-ShareableViewDefinition-notes.md
+++ b/input/pagecontent/StructureDefinition-ShareableViewDefinition-notes.md
@@ -1,7 +1,8 @@
 ### Required FHIRPath Expressions/Functions
 
-All View Runners claiming conformance to the Shareable View Definition profile SHALL implement these [FHIRPath](https://hl7.org/fhirpath/)
-capabilities:
+<span class="fhir-conformance" id="shareable-1">All View Runners claiming conformance to the
+Shareable View Definition profile SHALL implement these
+[FHIRPath](https://hl7.org/fhirpath/) capabilities:</span>
 
 -   [Literals](https://hl7.org/fhirpath/#literals) for String, Integer and Decimal
 -   [where](https://hl7.org/fhirpath/#wherecriteria-expression-collection)function

--- a/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
+++ b/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
@@ -2,16 +2,18 @@
 
 Columns within a view are defined using the [FHIRPath](https://hl7.org/fhirpath/) language. FHIRPath contains a large number of functions and syntax constructs - not all of these are required to be implemented within a SQL on FHIR view runner.
 
-View runner implementations MUST support the following required additional FHIRPath functions. In
+<span class="fhir-conformance" id="viewdef-8">View runner implementations SHALL support the
+following required additional FHIRPath functions.</span> In
 addition to this, <span class="fhir-conformance" id="viewdef-1">runners SHOULD implement the FHIRPath subset defined in the
 [Shareable View Definition](StructureDefinition-ShareableViewDefinition.html) profile if the intent is for the runner to be able to
 execute shared view definitions.</span>
 
 ### Required Additional Functions
 
-All View Runners SHALL implement these functions that extend the FHIRPath
-specification. Despite not being in the [FHIRPath](https://hl7.org/fhirpath/)
-specification, they are necessary in the context of defining views:
+<span class="fhir-conformance" id="viewdef-9">All View Runners SHALL implement these functions
+that extend the FHIRPath specification.</span> Despite not being in the
+[FHIRPath](https://hl7.org/fhirpath/) specification, they are necessary in the
+context of defining views:
 
 - [getResourceKey](#getresourcekey--keytype) function
 - [getReferenceKey](#getreferencekeyresource-type-specifier--keytype) function
@@ -27,9 +29,10 @@ with [getReferenceKey](#getreferencekeyresource-type-specifier--keytype),
 which returns
 an equal value from references that point to this resource.
 
-The returned _KeyType_ is implementation dependent, but SHALL be a FHIR primitive
-type that can be used for efficient joins in the system's underlying data
-storage. Integers, strings, UUIDs, and other primitive types may be appropriate.
+<span class="fhir-conformance" id="viewdef-10">The returned _KeyType_ is implementation
+dependent, but SHALL be a FHIR primitive type that can be used for efficient
+joins in the system's underlying data storage.</span> Integers, strings, UUIDs,
+and other primitive types may be appropriate.
 
 See
 the [Joins with Resource and Reference Keys](#joins-with-resource-and-reference-keys)
@@ -39,9 +42,9 @@ section below for details.
 
 This is invoked on [Reference](https://hl7.org/fhir/references.html#Reference)
 elements and returns an opaque value that represents the database key of the row
-being referenced. The value returned SHALL be equal to
-the [getResourceKey](#getresourcekey--keytype) value returned on the resource
-itself.
+being referenced. <span class="fhir-conformance" id="viewdef-11">The value returned SHALL be equal
+to the [getResourceKey](#getresourcekey--keytype) value returned on the resource
+itself.</span>
 
 Users may pass an optional resource type (e.g., Patient or Observation) to
 indicate the expected type of the resource the reference points to. The
@@ -51,17 +54,17 @@ expected type. For example, `Observation.subject.getReferenceKey(Patient)` would
 return a row key if the subject is a Patient, or the empty collection (
 i.e., `{}`) if it is not.
 
-The returned _KeyType_ is implementation dependent, but SHALL be a FHIR primitive
-type that can be used for efficient joins in the systems underlying data
-storage. Integers, strings, UUIDs, and other primitive types may be appropriate.
+<span class="fhir-conformance" id="viewdef-12">The returned _KeyType_ is implementation
+dependent, but SHALL be a FHIR primitive type that can be used for efficient
+joins in the systems underlying data storage.</span> Integers, strings, UUIDs, and other primitive types may be appropriate.
 
 The getReferenceKey function has both required and optional functionality:
 
-- Implementations MUST support the relative literal form of reference (
-  e.g., `Patient/123`), and <span class="fhir-conformance" id="viewdef-2">MAY support other
-  types of references.</span> If the implementation does not support the
-  reference type, or is unable to resolve the reference, it MUST return the
-  empty collection (i.e., `{}`).
+- <span class="fhir-conformance" id="viewdef-13">Implementations SHALL support the relative
+  literal form of reference (e.g., `Patient/123`)</span>, and <span class="fhir-conformance" id="viewdef-2">MAY support other
+  types of references.</span> <span class="fhir-conformance" id="viewdef-14">If the implementation
+  does not support the reference type, or is unable to resolve the reference, it
+  SHALL return the empty collection (i.e., `{}`).</span>
 - <span class="fhir-conformance" id="viewdef-3">Implementations MAY generate a list of
   unprocessable references through query responses, logging or
   reporting.</span> The details of how this information would be provided to the
@@ -294,8 +297,9 @@ This would produce a flat table with all items regardless of nesting depth:
 A `select` can have an optional `unionAll`, which contains a list of `select`s
 that are used to create a union. `unionAll` effectively concatenates the results
 of the nested `select`s that it contains, but without a guarantee that row
-ordering will be preserved. Each `select` contained in the `unionAll` SHALL
-produce the same columns including their specified names and FHIR types.
+ordering will be preserved. <span class="fhir-conformance" id="viewdef-15">Each `select` contained
+in the `unionAll` SHALL produce the same columns including their specified names
+and FHIR types.</span>
 
 ```js
 "select": {
@@ -328,10 +332,11 @@ The columns produced from the `unionAll` list are effectively added to the
 parent `select`, following any other columns from its parent for column
 ordering. See the [column ordering](#column-ordering) section below for details.
 
-The `select`s in a `unionAll` MUST have matching columns. Specifically, each
-nested selection structure MUST produce the same number of columns with the same
-names and order, and the values for the columns MUST be of the same types as
-determined by the [column types](#column-types) part of this specification.
+<span class="fhir-conformance" id="viewdef-16">The `select`s in a `unionAll` SHALL have matching
+columns. Specifically, each nested selection structure SHALL produce the same
+number of columns with the same names and order, and the values for the columns
+SHALL be of the same types as determined by the
+[column types](#column-types) part of this specification.</span>
 
 `unionAll` behaves similarly to the `UNION ALL` in SQL and will not filter out
 duplicate rows. Note that each `select` can contain only one `unionAll` list
@@ -402,8 +407,9 @@ included purely for illustrative purposes.
 
 ## Column Ordering
 
-View Runners that support column ordering in their output format MUST order
-the columns of the result according to the rules defined in this section.
+<span class="fhir-conformance" id="viewdef-17">View Runners that support column ordering in
+their output format SHALL order the columns of the result according to the rules
+defined in this section.</span>
 
 `select`s that have nested `select`s will place the columns of the
 parent `select` before the columns of the nested `select`, and the columns from
@@ -492,8 +498,8 @@ order:
 
 ## Column Types
 
-All values in a given column SHALL be of a single data type. The data type can be
-explicitly specified with
+<span class="fhir-conformance" id="viewdef-18">All values in a given column SHALL be of a single
+data type.</span> The data type can be explicitly specified with
 the [collection](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select.column.collection)
 and [type](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select.column.type)
 for a column. In most cases, the data type for a column can be determined by
@@ -503,9 +509,9 @@ ViewDefinition without needing to look up and explicitly specify the data type.
 If the column is a primitive type (typical of tabular output), its type is
 inferred under the following conditions:
 
-1. If
+1. <span class="fhir-conformance" id="viewdef-19">If
    the [collection](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select.column.collection)
-   is not set to `true`, the returned data type SHALL be a single value.
+   is not set to `true`, the returned data type SHALL be a single value.</span>
 2. If the `path` is a series of `parent.child.subPath` navigation steps from a
    known data type, either from the root resource or a child of an `ofType`
    function, then the data type for each column is determined by the structure
@@ -517,10 +523,10 @@ inferred under the following conditions:
 4. A path that ends in `ofType()` will be of the type given to that function.
 
 Note that type inference is an optional feature and some implementations may not
-support it. Therefore, a ViewDefinition that is intended to be shared between
-different implementations SHOULD have
+support it. <span class="fhir-conformance" id="viewdef-20">Therefore, a ViewDefinition that is
+intended to be shared between different implementations SHOULD have
 the [type](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select.column.type)
-for each column set explicitly, even for primitives. It is reasonable for an
+for each column set explicitly, even for primitives.</span> It is reasonable for an
 implementation to treat any non-specified types as strings. Moreover,
 non-primitive data types will not be supported by all implementations.
 Therefore, it is important to always explicitly set
@@ -821,9 +827,9 @@ to `active_patients.id` using common join semantics.
 
 ### Suggested Implementations for getResourceKey() and getReferenceKey()
 
-While [getResourceKey](#getresourcekey--keytype)
+<span class="fhir-conformance" id="viewdef-21">While [getResourceKey](#getresourcekey--keytype)
 and [getReferenceKey](#getreferencekeyresource-type-specifier--keytype) SHALL
-return matching values for the same row, _how_ they do so is left to the
+return matching values for the same row</span>, _how_ they do so is left to the
 implementation. This is by design, allowing ViewDefinitions to be run across a
 wide set of systems that have different data invariants or pre-processing
 capabilities.
@@ -853,9 +859,9 @@ Here are some implementation options to meet different needs:
     </tbody>
 </table>
 
-There are many variations and alternatives to the above. This specification
+There are many variations and alternatives to the above. <span class="fhir-conformance" id="viewdef-22">This specification
 simply asserts that implementations SHALL be able to produce a row key for each
-resource and a matching key for references pointing at that resource, and
+resource and a matching key for references pointing at that resource</span>, and
 intentionally leaves the specific mechanism to the implementation.
 
 ## Contained Resources
@@ -957,9 +963,9 @@ output format.</span>
 
 {:.table-data}
 
-Where the representation is `CHARACTER VARYING`, the format MUST comply with
-the string representation of that type within the
-[FHIR spec](https://www.hl7.org/fhir/R4/datatypes.html#primitive).
+<span class="fhir-conformance" id="viewdef-23">Where the representation is `CHARACTER VARYING`,
+the format SHALL comply with the string representation of that type within the
+[FHIR spec](https://www.hl7.org/fhir/R4/datatypes.html#primitive).</span>
 
 Where a path has both a FHIR type and a FHIRPath type, the FHIR type mapping
 will take precedence.
@@ -1013,9 +1019,9 @@ the desired implementation-specific type for a column.
 ## Processing Algorithm
 
 The following description provides an algorithm for how to process a FHIR
-resource as input for a ViewDefinition. Implementations do not need to follow
-this algorithm directly, but their outputs SHOULD be consistent with what this
-model produces.
+resource as input for a ViewDefinition. <span class="fhir-conformance" id="viewdef-24">Implementations do not need to
+follow this algorithm directly, but their outputs SHOULD be consistent with what
+this model produces.</span>
 
 ### Validate Columns (entry point)
 

--- a/input/pagecontent/contributing.md
+++ b/input/pagecontent/contributing.md
@@ -15,6 +15,7 @@ Contributors are welcome! Here are some places to start:
 * Nikolai Ryzhikov @niquola (Health Samurai)
 * Ryan Brush @rbrush (Google)
 * John Grimes @johngrimes (CSIRO)
+* Gino Canessa @ginocanessa (Microsoft)
 * Josh Mandel @jmandel (Microsoft)
 * Dan Gottlieb @gotdan (Central Square Solutions)
 * Arjun Sanyal @arjun (NCQA)

--- a/input/pagecontent/functional-model.md
+++ b/input/pagecontent/functional-model.md
@@ -347,8 +347,9 @@ To interpret such nodes, you have to re-order keywords (functions) according to
 precedence (higher bubble up):
 
 In a ViewDefinition, different keywords/functions can appear at the same level.
-To interpret such node in a ViewDefinition, an implementation SHALL reorder the
-keywords/functions according to the following precedence rule.
+<span class="fhir-conformance" id="fm-1">To interpret such node in a ViewDefinition, an
+implementation SHALL reorder the keywords/functions according to the following
+precedence rule.</span>
 
 Keyword/function reordering rule (highest to lowest precedence):
 

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -577,7 +577,8 @@ The export operation conforms to the
   body explaining the failure; repeated fetches return the same outcome within
   the validity window.
 
-Clients MUST treat the status and result URLs as opaque values. Note that many
+<span class="fhir-conformance" id="com-23">Clients SHALL treat the status and result URLs as
+opaque values.</span> Note that many
 HTTP libraries follow a `303` response to a `GET` automatically, so a polling
 client may transparently receive the result response; this is benign.
 

--- a/input/pagecontent/operations.md
+++ b/input/pagecontent/operations.md
@@ -139,7 +139,8 @@ reference it rather than restating it.
 
 ### CapabilityStatement
 
-Server MUST support CapabilityStatement API for discovery of supported operations.
+<span class="fhir-conformance" id="ops-2">Server SHALL support CapabilityStatement API for
+discovery of supported operations.</span>
 
 See [CapabilityStatement for SQL-on-FHIR API](operations-capability.html)
 

--- a/input/resources/viewdefinition/StructureDefinition-ShareableViewDefinition.xml
+++ b/input/resources/viewdefinition/StructureDefinition-ShareableViewDefinition.xml
@@ -5,13 +5,13 @@
   <url value="http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ShareableViewDefinition"/>
   <name value="ShareableViewDefinition"/>
   <title value="Shareable View Definition"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="A profile for View Definitions intended to be shared between multiple systems. This requires that &#xA;the View Definition have a defined URL and name. It also requires declaration of the FHIR version &#xA;that the view is intended to be executed over, and the FHIR type of each column. This ensures &#xA;consistent interpretation of the view across different view runner implementations."/>
   <fhirVersion value="5.0.0"/>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="ViewDefinition"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ViewDefinition"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot"/>
   <derivation value="constraint"/>
   <differential>
     <element id="ViewDefinition">

--- a/input/resources/viewdefinition/StructureDefinition-TabularViewDefinition.xml
+++ b/input/resources/viewdefinition/StructureDefinition-TabularViewDefinition.xml
@@ -5,13 +5,13 @@
   <url value="http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/TabularViewDefinition"/>
   <name value="TabularViewDefinition"/>
   <title value="Tabular View Definition"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="A profile for View Definitions where each resulting field must contain only a simple scalar value.&#xA;This is sometimes referred to as 'CSV Mode', but applies to any system that explicitly constrains &#xA;its views or tables to tabular data."/>
   <fhirVersion value="5.0.0"/>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="ViewDefinition"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ViewDefinition"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot"/>
   <derivation value="constraint"/>
   <differential>
     <element id="ViewDefinition">

--- a/input/resources/viewdefinition/StructureDefinition-ViewDefinition.xml
+++ b/input/resources/viewdefinition/StructureDefinition-ViewDefinition.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StructureDefinition xmlns="http://hl7.org/fhir">
+<StructureDefinition xmlns="http://hl7.org/fhir" resourceDefinition="http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot">
   <id value="ViewDefinition"/>
+	<extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-resource">
+		<valueBoolean value="true"/>
+	</extension>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category">
+		<valueCode value="anonymous"/>
+	</extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
     <valueCode value="draft"/>
   </extension>

--- a/input/resources/viewdefinition/ViewDefinition-CodeSystemHierarchy.json
+++ b/input/resources/viewdefinition/ViewDefinition-CodeSystemHierarchy.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "CodeSystemHierarchy",
   "name": "code_system_hierarchy",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-ConditionFlat.json
+++ b/input/resources/viewdefinition/ViewDefinition-ConditionFlat.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "ConditionFlat",
   "name": "condition_flat",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-EncounterFlat.json
+++ b/input/resources/viewdefinition/ViewDefinition-EncounterFlat.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "EncounterFlat",
   "name": "encounter_flat",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-PatientAddresses.json
+++ b/input/resources/viewdefinition/ViewDefinition-PatientAddresses.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "PatientAddresses",
   "name": "patient_addresses",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-PatientAndContactAddressUnion.json
+++ b/input/resources/viewdefinition/ViewDefinition-PatientAndContactAddressUnion.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "PatientAndContactAddressUnion",
   "name": "patient_and_contact_addresses",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-PatientDemographics.json
+++ b/input/resources/viewdefinition/ViewDefinition-PatientDemographics.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "PatientDemographics",
   "name": "patient_demographics",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-PatientNamesWithIndex.json
+++ b/input/resources/viewdefinition/ViewDefinition-PatientNamesWithIndex.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "PatientNamesWithIndex",
   "name": "patient_names_with_index",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-QuestionnaireResponseItems.json
+++ b/input/resources/viewdefinition/ViewDefinition-QuestionnaireResponseItems.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "QuestionnaireResponseItems",
   "name": "questionnaire_response_items",
   "status": "draft",

--- a/input/resources/viewdefinition/ViewDefinition-ShareablePatientDemographics.json
+++ b/input/resources/viewdefinition/ViewDefinition-ShareablePatientDemographics.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "ShareablePatientDemographics",
   "meta": {
     "profile": [

--- a/input/resources/viewdefinition/ViewDefinition-UsCoreBloodPressures.json
+++ b/input/resources/viewdefinition/ViewDefinition-UsCoreBloodPressures.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "ViewDefinition",
+  "resourceDefinition" : "http://hl7.org/fhir/StructureDefinition/ViewDefinition|3.0.0-ballot",
   "id": "UsCoreBloodPressures",
   "name": "us_core_blood_pressures",
   "status": "draft",

--- a/input/resources/viewdefinition/bundle-ViewDefinition-search-params.xml
+++ b/input/resources/viewdefinition/bundle-ViewDefinition-search-params.xml
@@ -10,7 +10,7 @@
         <id value="ViewDefinition-context"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-context"/>
         <name value="ViewDefinitionContext"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A use context assigned to the view definition"/>
         <code value="context"/>
         <base value="ViewDefinition"/>
@@ -27,7 +27,7 @@
         <id value="ViewDefinition-context-quantity"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-context-quantity"/>
         <name value="ViewDefinitionContextQuantity"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A quantity- or range-valued use context assigned to the view definition"/>
         <code value="context-quantity"/>
         <base value="ViewDefinition"/>
@@ -44,7 +44,7 @@
         <id value="ViewDefinition-context-type"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-context-type"/>
         <name value="ViewDefinitionContextType"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A type of use context assigned to the view definition"/>
         <code value="context-type"/>
         <base value="ViewDefinition"/>
@@ -61,7 +61,7 @@
         <id value="ViewDefinition-context-type-quantity"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-context-type-quantity"/>
         <name value="ViewDefinitionContextTypeQuantity"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A use context type and quantity- or range-based value assigned to the view definition"/>
         <code value="context-type-quantity"/>
         <base value="ViewDefinition"/>
@@ -86,7 +86,7 @@
         <id value="ViewDefinition-context-type-value"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-context-type-value"/>
         <name value="ViewDefinitionContextTypeValue"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A use context type and value assigned to the view definition"/>
         <code value="context-type-value"/>
         <base value="ViewDefinition"/>
@@ -111,7 +111,7 @@
         <id value="ViewDefinition-date"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-date"/>
         <name value="ViewDefinitionDate"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The view definition publication date"/>
         <code value="date"/>
         <base value="ViewDefinition"/>
@@ -128,7 +128,7 @@
         <id value="ViewDefinition-description"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-description"/>
         <name value="ViewDefinitionDescription"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The description of the view definition"/>
         <code value="description"/>
         <base value="ViewDefinition"/>
@@ -145,7 +145,7 @@
         <id value="ViewDefinition-identifier"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-identifier"/>
         <name value="ViewDefinitionIdentifier"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="External identifier for the view definition"/>
         <code value="identifier"/>
         <base value="ViewDefinition"/>
@@ -162,7 +162,7 @@
         <id value="ViewDefinition-jurisdiction"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-jurisdiction"/>
         <name value="ViewDefinitionJurisdiction"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="Intended jurisdiction for the view definition"/>
         <code value="jurisdiction"/>
         <base value="ViewDefinition"/>
@@ -179,7 +179,7 @@
         <id value="ViewDefinition-name"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-name"/>
         <name value="ViewDefinitionName"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="Computationally friendly name of the view definition"/>
         <code value="name"/>
         <base value="ViewDefinition"/>
@@ -196,7 +196,7 @@
         <id value="ViewDefinition-profile"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-profile"/>
         <name value="ViewDefinitionProfile"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="A FHIR profile the view definition is intended to be executed against"/>
         <code value="profile"/>
         <base value="ViewDefinition"/>
@@ -214,7 +214,7 @@
         <id value="ViewDefinition-publisher"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-publisher"/>
         <name value="ViewDefinitionPublisher"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="Name of the publisher of the view definition"/>
         <code value="publisher"/>
         <base value="ViewDefinition"/>
@@ -231,7 +231,7 @@
         <id value="ViewDefinition-resource"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-resource"/>
         <name value="ViewDefinitionResource"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The FHIR resource type the view definition is based upon"/>
         <code value="resource"/>
         <base value="ViewDefinition"/>
@@ -248,7 +248,7 @@
         <id value="ViewDefinition-status"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-status"/>
         <name value="ViewDefinitionStatus"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The current status of the view definition"/>
         <code value="status"/>
         <base value="ViewDefinition"/>
@@ -265,7 +265,7 @@
         <id value="ViewDefinition-title"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-title"/>
         <name value="ViewDefinitionTitle"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The human-friendly name of the view definition"/>
         <code value="title"/>
         <base value="ViewDefinition"/>
@@ -282,7 +282,7 @@
         <id value="ViewDefinition-url"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-url"/>
         <name value="ViewDefinitionUrl"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The uri that identifies the view definition"/>
         <code value="url"/>
         <base value="ViewDefinition"/>
@@ -299,7 +299,7 @@
         <id value="ViewDefinition-version"/>
         <url value="http://hl7.org/fhir/uv/sql-on-fhir/SearchParameter/ViewDefinition-version"/>
         <name value="ViewDefinitionVersion"/>
-        <status value="draft"/>
+        <status value="active"/>
         <description value="The business version of the view definition"/>
         <code value="version"/>
         <base value="ViewDefinition"/>

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -8,7 +8,7 @@ canonical: http://hl7.org/fhir/uv/sql-on-fhir
 name: SQLonFHIR
 title: SQL on FHIR
 description: A specification for defining portable views of FHIR data that can be easily queried using tools such as SQL.
-status: draft # draft | active | retired | unknown
+status: active # draft | active | retired | unknown
 version: 3.0.0-ballot
 fhirVersion: 6.0.0-ballot3 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2023+
@@ -22,7 +22,9 @@ extension:
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg
     valueCode: fhir
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
-    valueCode: draft
+    valueCode: trial-use
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm
+    valueInteger: 2
 publisher:
   name: HL7 International / FHIR Infrastructure
   url: http://www.hl7.org/Special/committees/fiwg


### PR DESCRIPTION
This pull request introduces a series of documentation improvements to the conformance statements across multiple operation and structure definition markdown files. The main changes involve standardizing and clarifying normative language by explicitly marking conformance requirements with `<span class="fhir-conformance" ...>` wrappers and unique IDs, improving the visibility and traceability of requirements for implementers.

The most important changes are:

**Conformance Statement Standardization and Clarity**
* All normative requirements (e.g., SHALL, SHOULD, MUST) in operation and structure definition documentation are now wrapped in `<span class="fhir-conformance" id="...">...</span>` elements with unique IDs, making them easier to identify and reference. [[1]](diffhunk://#diff-49e0578149c049e36963efd57f0adfd383843edc8dee5f347ae941a4b4ff7c63L19-R19) [[2]](diffhunk://#diff-49e0578149c049e36963efd57f0adfd383843edc8dee5f347ae941a4b4ff7c63L445-R445) [[3]](diffhunk://#diff-49e0578149c049e36963efd57f0adfd383843edc8dee5f347ae941a4b4ff7c63L660-R661) [[4]](diffhunk://#diff-49e0578149c049e36963efd57f0adfd383843edc8dee5f347ae941a4b4ff7c63L682-R682) [[5]](diffhunk://#diff-3b093cbda0a4dd6d615a8091eaecfd15f83f3cb0cab081ec9c3022c2e87cabddL36-R40) [[6]](diffhunk://#diff-c7fdfdc272e8a5ca61d218d10a5d35ff6bf52517be594ce7d3107424cf629aecL791-R792) [[7]](diffhunk://#diff-c7fdfdc272e8a5ca61d218d10a5d35ff6bf52517be594ce7d3107424cf629aecL831-R833) [[8]](diffhunk://#diff-e9e482fa804c91a99caf44853714aff8dd96237c0b266fa632a9234381ef2a82L38-R40) [[9]](diffhunk://#diff-e9e482fa804c91a99caf44853714aff8dd96237c0b266fa632a9234381ef2a82L59-R63) [[10]](diffhunk://#diff-8b3772d9b1cb2ecfc1e096eecb656615c504b4fdd70623c642951054d063dc89L92-R98) [[11]](diffhunk://#diff-e8d745461826a0f886c857c8254f922fd2e33ba977f31b577d52736deccabc9eL3-R5) [[12]](diffhunk://#diff-3f6efff893c09e1b5ae2fe49ce81b5eabe25bf6a681fdaead385d1f8815dd346L5-R16)

**Security and Parameter Binding Requirements**
* Security-related requirements for parameter binding in SQL queries are now explicitly marked as conformance statements, clarifying that implementations SHALL use safe binding and SHALL NOT use string interpolation to prevent SQL injection. [[1]](diffhunk://#diff-3b093cbda0a4dd6d615a8091eaecfd15f83f3cb0cab081ec9c3022c2e87cabddL36-R40) [[2]](diffhunk://#diff-e9e482fa804c91a99caf44853714aff8dd96237c0b266fa632a9234381ef2a82L59-R63)

**SQL Query and Result Handling**
* Requirements for SQL query parameter types, result encoding, and error handling (such as returning a 422 error for unsupported SQL types) are now clearly tagged as conformance statements, improving guidance for both server and client implementers. [[1]](diffhunk://#diff-c7fdfdc272e8a5ca61d218d10a5d35ff6bf52517be594ce7d3107424cf629aecL791-R792) [[2]](diffhunk://#diff-c7fdfdc272e8a5ca61d218d10a5d35ff6bf52517be594ce7d3107424cf629aecL831-R833) [[3]](diffhunk://#diff-8b3772d9b1cb2ecfc1e096eecb656615c504b4fdd70623c642951054d063dc89L92-R98)

**View Definition and FHIRPath Support**
* The set of required FHIRPath functions and extensions that view runner implementations must support are now explicitly marked with conformance tags, making the expectations for implementers more precise. [[1]](diffhunk://#diff-e8d745461826a0f886c857c8254f922fd2e33ba977f31b577d52736deccabc9eL3-R5) [[2]](diffhunk://#diff-3f6efff893c09e1b5ae2fe49ce81b5eabe25bf6a681fdaead385d1f8815dd346L5-R16)

**Editorial and Minor Content Updates**
* Minor editorial changes were made for clarity and consistency, such as updating language for future intent and improving section numbering in `ignoreWarnings.txt`.

These changes collectively improve the structure, clarity, and enforceability of conformance requirements in the documentation.